### PR TITLE
Fix wrong namespace use for RestApiException in CalendarManager

### DIFF
--- a/src/Outlook/Calendars/CalendarManager.php
+++ b/src/Outlook/Calendars/CalendarManager.php
@@ -8,7 +8,7 @@ namespace Outlook\Calendars;
 
 use Outlook\ApiRequester\Client;
 use Outlook\Authorizer\Token;
-use Outlook\Exceptions\Calenders\RestApiException;
+use Outlook\Exceptions\Events\RestApiException;
 
 class CalendarManager
 {


### PR DESCRIPTION
See https://github.com/sagarrabadiya/outlook-php/issues/12#issuecomment-462133489